### PR TITLE
Support comma-separated list of required users

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,12 @@ jobs:
 
 In this setup, the step will succeed if there's any comment written by `john-doe` in your pull-request.
 If `john-doe` did not comment in this pull-request, the job will fail.
+
+### Multiple users
+
+You can specify multiple users by separating them with commas. The step will succeed if **any** of the listed users has commented:
+
+```yml
+env:
+  REQUIRED_COMMENT_USER: "linear[bot],linear-code[bot]"
+```

--- a/core/search_pull_request_comments.py
+++ b/core/search_pull_request_comments.py
@@ -23,7 +23,11 @@ def search_comments(github_info, token: str, required_user):
     review_comments = fetch(links["review_comments"]["href"], token)
 
     users_that_left_a_comment = [c["user"]["login"] for c in (simple_comments + review_comments)]
-    required_user_has_commented = str(required_user) in users_that_left_a_comment
+
+    required_users = [u.strip() for u in str(required_user).split(",")]
+    required_user_has_commented = any(
+        u in users_that_left_a_comment for u in required_users
+    )
 
     return {
         "comments": users_that_left_a_comment,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "User to search: $REQUIRED_COMMENT_USER"
+echo "User(s) to search: $REQUIRED_COMMENT_USER"
 
 result=$(python3 /search_pull_request_comments.py "$EVENT_DETAILS" "$GITHUB_TOKEN" "$REQUIRED_COMMENT_USER")
 
@@ -9,7 +9,7 @@ echo "Result: $result"
 if [ "$result" = "0" ]; then
     echo "User that was required to comment did leave a comment - all good!"
 else
-    echo "Couldn't find any comment from the required user\n"
+    echo "Couldn't find any comment from any of the required users"
     echo "Here's everyone that did comment: $result"
     exit 1
 fi


### PR DESCRIPTION
## Problem

Linear recently changed their bot username from `linear[bot]` to `linear-code[bot]`, breaking workflows that relied on an exact match against `REQUIRED_COMMENT_USER`.

## Solution

Allow `REQUIRED_COMMENT_USER` to accept a comma-separated list of usernames. The check succeeds if **any** of the listed users has left a comment.

Example:
```yml
env:
  REQUIRED_COMMENT_USER: "linear[bot],linear-code[bot]"
```

This is fully backwards-compatible — a single username still works exactly as before.

## Changes

- `core/search_pull_request_comments.py`: Split `required_user` on commas and check if any of the resulting usernames appear in the commenters list.
- `entrypoint.sh`: Updated log messages to reflect multiple users.
- `README.md`: Documented the new multi-user feature.


Made with [Cursor](https://cursor.com)