### PR TITLE
fix: add pagination, error handling, and modernize runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
-FROM python:3.7-slim
-
-USER root
-
-RUN apt-get update
-RUN apt-get install -y curl jq
+FROM python:3.13-slim
 
 COPY core/requirements.txt /requirements.txt
-RUN pip3 install -r /requirements.txt
+RUN pip3 install --no-cache-dir -r /requirements.txt
 
 COPY core/search_pull_request_comments.py /search_pull_request_comments.py
 COPY entrypoint.sh /entrypoint.sh
 
-RUN chmod +x entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Search pull-request comments Action
 
 Searches a pull-request for any comment left by a specific user. If no comment is found, the step fails.
-Searches through both simple and review comments.
+Searches through both issue comments and review comments, with full pagination support.
 
 ## Installation
 
@@ -14,11 +14,10 @@ on: pull_request
 jobs:
   search_pull_request_comments:
     runs-on: ubuntu-latest
-    container: python:3.7-slim
 
     steps:
       - name: Search pull-request comments
-        uses: peterkrauz/search-pull-request-comments@v0.0.8
+        uses: peterkrauz/search-pull-request-comments@v0
         env:
           REQUIRED_COMMENT_USER: "john-doe"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -1,5 +1,1 @@
-certifi==2021.10.8
-charset-normalizer==2.0.12
-idna==3.3
-requests==2.27.1
-urllib3==1.26.8
+requests==2.32.3

--- a/core/search_pull_request_comments.py
+++ b/core/search_pull_request_comments.py
@@ -1,46 +1,96 @@
-import logging
-from json import loads, dumps
+from __future__ import annotations
 
+import sys
+from json import loads
+from typing import Any
 import requests
 
-logger = logging.getLogger(__name__)
+MAX_PAGES = 10
+PER_PAGE = 100
 
 
-def fetch(url: str, token: str) -> list:
-    headers = {"Accept": "application/vnd.github.v3+json", "Authorization": f"token {token}"}
-    return requests.get(url, headers=headers).json()
-
-
-def search_comments(github_info, token: str, required_user):
-    if isinstance(github_info, str):
-        github_info = loads(github_info)
-
-    if "event" in github_info:
-        github_info = github_info["event"]
-
-    links = github_info["pull_request"]["_links"]
-    simple_comments = fetch(links["comments"]["href"], token)
-    review_comments = fetch(links["review_comments"]["href"], token)
-
-    users_that_left_a_comment = [c["user"]["login"] for c in (simple_comments + review_comments)]
-
-    required_users = [u.strip() for u in str(required_user).split(",")]
-    required_user_has_commented = any(
-        u in users_that_left_a_comment for u in required_users
-    )
-
-    return {
-        "comments": users_that_left_a_comment,
-        "required_user_has_commented": required_user_has_commented
+def fetch_all_pages(url: str, token: str) -> list[dict[str, Any]]:
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": f"token {token}",
     }
+
+    separator = "&" if "?" in url else "?"
+    paginated_url = f"{url}{separator}per_page={PER_PAGE}"
+
+    accumulated: list[dict[str, Any]] = []
+    for _ in range(MAX_PAGES):
+        response = requests.get(paginated_url, headers=headers, timeout=30)
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"GitHub API returned {response.status_code} for {paginated_url}: "
+                f"{response.text[:200]}"
+            )
+
+        page_data = response.json()
+        if not isinstance(page_data, list):
+            raise TypeError(
+                f"Expected list from GitHub API, got {type(page_data).__name__}"
+            )
+
+        accumulated.extend(page_data)
+
+        next_url = _parse_next_link(response.headers.get("Link", ""))
+        if next_url is None:
+            break
+        paginated_url = next_url
+
+    return accumulated
+
+
+def _parse_next_link(link_header: str) -> str | None:
+    for part in link_header.split(","):
+        if 'rel="next"' in part:
+            start = part.index("<") + 1
+            end = part.index(">")
+            return part[start:end]
+    return None
+
+
+def extract_commenters(event_json: str, token: str, required_user_csv: str) -> int:
+    event = _parse_event(event_json)
+    links = event["pull_request"]["_links"]
+
+    issue_comments = fetch_all_pages(links["comments"]["href"], token)
+    review_comments = fetch_all_pages(links["review_comments"]["href"], token)
+
+    commenters = {
+        comment["user"]["login"]
+        for comment in (*issue_comments, *review_comments)
+    }
+
+    required_users = [u.strip() for u in required_user_csv.split(",")]
+    if any(user in commenters for user in required_users):
+        return 0
+
+    print(
+        f"Required: {required_users}. "
+        f"Found: {sorted(commenters) if commenters else '(none)'}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _parse_event(raw: str) -> dict[str, Any]:
+    parsed = loads(raw)
+    if not isinstance(parsed, dict):
+        raise TypeError(f"Expected dict from event JSON, got {type(parsed).__name__}")
+    if "event" in parsed:
+        return parsed["event"]
+    return parsed
 
 
 if __name__ == "__main__":
-    import sys
+    if len(sys.argv) != 4:
+        raise SystemExit(
+            f"Usage: {sys.argv[0]} <event_json> <github_token> <required_users>"
+        )
 
-    result = search_comments(sys.argv[1], sys.argv[2], sys.argv[3])
-
-    if result["required_user_has_commented"]:
-        print(0)
-    else:
-        print(result["comments"])
+    raise SystemExit(
+        extract_commenters(sys.argv[1], sys.argv[2], sys.argv[3])
+    )

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,9 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "User(s) to search: $REQUIRED_COMMENT_USER"
 
-result=$(python3 /search_pull_request_comments.py "$EVENT_DETAILS" "$GITHUB_TOKEN" "$REQUIRED_COMMENT_USER")
-
-echo "Result: $result"
-
-if [ "$result" = "0" ]; then
-    echo "User that was required to comment did leave a comment - all good!"
-else
-    echo "Couldn't find any comment from any of the required users"
-    echo "Here's everyone that did comment: $result"
-    exit 1
-fi
+python3 /search_pull_request_comments.py \
+    "$EVENT_DETAILS" \
+    "$GITHUB_TOKEN" \
+    "$REQUIRED_COMMENT_USER"


### PR DESCRIPTION
## Summary

- **Paginate GitHub API responses** — follows `Link: rel="next"` headers, fetching up to 1,000 comments (10 pages × 100). Previously only the first 30 were fetched, causing false negatives on active PRs.
- **Handle HTTP errors** — raises with status code and response body excerpt instead of silently parsing error JSON as comment data.
- **Modernize runtime** — Python 3.7 (EOL since June 2023) → 3.13, `requests` 2.27.1 → 2.32.3, removed unused `curl`/`jq` from the Docker image.

### Other improvements
- Exit code protocol replaces fragile `"0"` stdout sentinel
- Failure output goes to stderr as human-readable text instead of a Python list repr
- `set -euo pipefail` in entrypoint
- Full type annotations on all functions
- Removed unused imports (`logging`, `dumps`)
- README updated: version ref `@v0`, removed unnecessary `container:` line, mentions pagination

## Test plan

- [ ] Create a release on a fork and verify the publish workflow succeeds
- [ ] Trigger the action on a PR with <30 comments — should behave as before
- [ ] Trigger the action on a PR with >30 comments — should now find users beyond page 1
- [ ] Verify failure output is readable in the Actions log
- [ ] Verify a revoked/invalid token produces a clear `RuntimeError` instead of a crash